### PR TITLE
Better implicit fn calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,32 +60,6 @@ double (5 + 3)
 
 This will now give you the result you wanted.
 
-Another problem you might come across is this:
-
-```r
-def $a plus $b {
-  a + b
-}
-```
-
-How would you call this? If you did the following:
-
-```r
-5 plus 10
-```
-
-You'd get an error. This is because the current grammar only allows for _implicit function calls_ if the first
-item in the pattern is an identifier, and not an argument. In this case, you need to use an _explicit function call_:
-
-```r
-\5 plus 10
-```
-
-This would work exactly as you'd expect, returning the value `15`.
-
-In the future, I want to change the syntax so you *could* just write `5 plus 10`, since it's quite common for a
-pattern to begin with an argument.
-
 ## Defining your own if expression
 
 Because of the function calling  syntax, you can actually define your  own pseudo-syntactical constructs. For

--- a/TODO
+++ b/TODO
@@ -7,7 +7,7 @@ META
   add a literate Pluto file type (maybe .lpluto)
   make a Windows install script
   'pluto publish' command to publish a package
-  create some proper documentation
+  create some proper documentation, maybe using a GitHub wiki
 
 LANGUAGE
   only throw one syntax error per statement

--- a/TODO
+++ b/TODO
@@ -7,6 +7,7 @@ META
   add a literate Pluto file type (maybe .lpluto)
   make a Windows install script
   'pluto publish' command to publish a package
+  create some proper documentation
 
 LANGUAGE
   only throw one syntax error per statement

--- a/TODO
+++ b/TODO
@@ -9,7 +9,6 @@ META
   'pluto publish' command to publish a package
 
 LANGUAGE
-  only require explicit (\) function calls when the pattern len == 1
   only throw one syntax error per statement
   compile Pluto to bytecode to speed up execution?
   allow blocks to be curried

--- a/evaluation/eval-expressions.go
+++ b/evaluation/eval-expressions.go
@@ -538,17 +538,25 @@ func evalFunctionCall(node ast.FunctionCall, ctx *Context) Object {
 	}
 
 	if function, ok := fn.(Builtin); ok {
+		ps := patternString(node.Pattern)
+
 		for i, item := range node.Pattern {
 			fItem := function.Pattern[i]
 
 			if arg, ok := item.(*ast.Argument); ok {
-				if fItem[0] == '$' {
-					evaled := eval(arg.Value, ctx)
-					if IsErr(evaled) {
-						return evaled
-					}
+				evaled := eval(arg.Value, ctx)
+				if IsErr(evaled) {
+					return evaled
+				}
 
+				if fItem[0] == '$' {
 					args[fItem[1:]] = evaled
+				} else {
+					return Err(ctx, "no function matching the pattern: %s", "NotFoundError", ps)
+				}
+			} else if _, ok := item.(*ast.Identifier); ok {
+				if fItem[0] == '$' {
+					return Err(ctx, "no function matching the pattern: %s", "NotFoundError", ps)
 				}
 			}
 		}

--- a/examples/basic.pluto
+++ b/examples/basic.pluto
@@ -1,12 +1,14 @@
 #!/usr/bin/env pluto
 
+use "maths"
+
 def print two times $n {
   print (2 * n)
 }
 
 print two times 5
 
-print "the 5th root of 10 is %s" with (\5th root of 10,)
+print "the 5th root of 10 is {}" with (5th root of 10,)
 
 # basic types
 pi = 3.14159

--- a/examples/blocks.pluto
+++ b/examples/blocks.pluto
@@ -10,15 +10,15 @@ do { print "No arguments!" }
 six = do $triple with (2,)
 
 # they are used in a lot of builtins
-squares = map { |_, x| -> x ** 2 } over (\1 to 11)
+squares = map { |_, x| -> x ** 2 } over (1 to 10)
 print "Squares: {}" with (squares,)
 
 # they make it easy to define lots of functions
 def $n factorial {
-  fold (\1 to (n + 1)) with { |result, n| -> result * n }
+  fold (1 to $n) with { |result, n| -> result * n }
 }
 
-print "5! = {}" with (\5 factorial,)
+print "5! = {}" with (5 factorial,)
 
 # the declare operator (:=)
 #   when using the normal assignment operator (=), the assignment can affect parent scopes.

--- a/examples/factorial.pluto
+++ b/examples/factorial.pluto
@@ -3,5 +3,5 @@
 def $n factorial {
   if (n < 2) { return 1 }
   
-  return n * \(n - 1) factorial
+  return n * (n - 1) factorial
 }

--- a/examples/looping.pluto
+++ b/examples/looping.pluto
@@ -32,7 +32,7 @@ for (i : range $word) {
 new line
 
 # you get the usual loop control statements too:
-for (i : \1 to 10) {
+for (i : 1 to 10) {
   if (i == 4) {
     next
   } elif (i == 7) {

--- a/examples/syntax-errors.pluto
+++ b/examples/syntax-errors.pluto
@@ -1,3 +1,3 @@
 #!/usr/bin/env pluto
 
-"hello" "world"
+"hello" (--) "world"

--- a/install.sh
+++ b/install.sh
@@ -31,6 +31,7 @@ echo "DONE"
 # install standard libraries
 echo "installing standard libraries... "
 plp +maths +collections > /dev/null
+echo "DONE"
 
 echo
 echo "pluto and plp have been installed!"

--- a/parser/error.go
+++ b/parser/error.go
@@ -14,6 +14,7 @@ type Error struct {
 	Start, End token.Position
 }
 
+// Err creates an Error instance with the given arguments
 func (p *Parser) Err(msg string, start, end token.Position) {
 	err := Error{
 		Message: msg,

--- a/parser/etc.go
+++ b/parser/etc.go
@@ -1,6 +1,7 @@
 package parser
 
 import "github.com/Zac-Garby/pluto/token"
+import "github.com/Zac-Garby/pluto/ast"
 
 const (
 	lowest = iota
@@ -81,4 +82,13 @@ func isBlacklisted(t token.Type) bool {
 	}
 
 	return false
+}
+
+func isArgNode(n ast.Node) bool {
+	switch n.(type) {
+	case *ast.Parameter, *ast.Char, *ast.Tuple, *ast.String, *ast.Number, *ast.BlockLiteral, *ast.Identifier:
+		return true
+	default:
+		return false
+	}
 }

--- a/parser/etc.go
+++ b/parser/etc.go
@@ -70,6 +70,7 @@ var argBlacklist = []token.Type{
 	token.Plus,
 	token.LeftSquare,
 	token.Try,
+	token.Bang,
 }
 
 func isBlacklisted(t token.Type) bool {

--- a/parser/etc.go
+++ b/parser/etc.go
@@ -85,10 +85,6 @@ func isBlacklisted(t token.Type) bool {
 }
 
 func isArgNode(n ast.Node) bool {
-	switch n.(type) {
-	case *ast.Parameter, *ast.Char, *ast.Tuple, *ast.String, *ast.Number, *ast.BlockLiteral, *ast.Identifier:
-		return true
-	default:
-		return false
-	}
+	_, ok := n.(ast.Expression)
+	return ok
 }

--- a/parser/etc.go
+++ b/parser/etc.go
@@ -69,6 +69,7 @@ var argBlacklist = []token.Type{
 	token.Minus,
 	token.Plus,
 	token.LeftSquare,
+	token.Try,
 }
 
 func isBlacklisted(t token.Type) bool {

--- a/parser/expressions.go
+++ b/parser/expressions.go
@@ -8,6 +8,8 @@ import (
 	"github.com/Zac-Garby/pluto/token"
 )
 
+// parseExpression parses an expression starting at the current token.
+// The parsing method it uses is a modified pratt parser.
 func (p *Parser) parseExpression(precedence int) ast.Expression {
 	prefix, prefixExists := p.prefixes[p.cur.Type]
 

--- a/parser/statements.go
+++ b/parser/statements.go
@@ -143,13 +143,13 @@ func (p *Parser) parseClassDeclaration() ast.Statement {
 		return nil
 	}
 
-	stmt.Name = p.parseNonFnID()
+	stmt.Name = p.parseID()
 
 	if p.peekIs(token.Extends) {
 		p.next()
 		p.next()
 
-		stmt.Parent = p.parseNonFnID()
+		stmt.Parent = p.parseID()
 	}
 
 	if !p.expect(token.LeftBrace) {

--- a/parser/sub-parsers.go
+++ b/parser/sub-parsers.go
@@ -87,12 +87,12 @@ func (p *Parser) parseParams(end token.Type) []ast.Expression {
 	}
 
 	p.next()
-	params = append(params, p.parseNonFnID())
+	params = append(params, p.parseID())
 
 	for p.peekIs(token.Comma) {
 		p.next()
 		p.next()
-		params = append(params, p.parseNonFnID())
+		params = append(params, p.parseID())
 	}
 
 	if !p.expect(end) {

--- a/pluto.go
+++ b/pluto.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	"github.com/Zac-Garby/pluto/evaluation"
 	"github.com/Zac-Garby/pluto/parser"
@@ -73,6 +74,7 @@ func runREPL(ctx *evaluation.Context) {
 		reader := bufio.NewReader(os.Stdin)
 		fmt.Print(">> ")
 		text, _ := reader.ReadString('\n')
+		text = strings.TrimRight(text, "\n")
 
 		execute(text, true, ctx)
 	}

--- a/token/types.go
+++ b/token/types.go
@@ -50,10 +50,10 @@ const (
 	BackSlash = "backslash"
 
 	// LeftParen is a left paren '('
-	LeftParen = "lparen"
+	LeftParen = "left-paren"
 
 	// RightParen is a right paren ')'
-	RightParen = "rparen"
+	RightParen = "right-paren"
 
 	// LessThan is the less than operator (<)
 	LessThan = "less-than"


### PR DESCRIPTION
Function calls can now start with an argument (i.e. `5`, `$foo`) without requiring an explicit function call.

Also, the first expression can be literally any expression - but the rest of the arguments still have to be valid pattern expressions.